### PR TITLE
Suggestion: Use Macros appropriately

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Table of Contents:
   * [Strings](#strings)
     * [IOLists over string concatenation](#iolists-over-string-concatenation)
   * [Macros](#macros)
+    * [No Macros](#no-macros)
     * [Uppercase Macros](#uppercase-macros)
     * [No module or function name macros](#no-module-or-function-name-macros)
   * [Misc](#misc)
@@ -234,6 +235,16 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 *Reasoning*: Performance
 
 ### Macros
+
+***
+##### No Macros
+> Don't use macros, except for very specific cases, that include
+> * Predefined ones: ``?MODULE``, ``?MODULE_STRING`` and ``?LINE``
+> * Magic numbers: ``?DEFAULT_TIMEOUT``
+
+*Examples*: [macros](src/macros.erl)
+
+*Reasoning*: Macros make code harder to debug. If you're trying to use them to avoid repeating the same block of code over and over, you can use functions for that.
 
 ***
 ##### Uppercase macros

--- a/src/macro_names.erl
+++ b/src/macro_names.erl
@@ -1,9 +1,9 @@
 -module(macro_names).
 
--define(bad, bad).
--define(BADMACRONAME, bad).
--define(Bad_Macro_Name, bad).
--define(Bad_L33t_M@Cr0, bad).
+-define(bad, 1).
+-define(BADMACRONAME, 2).
+-define(Bad_Macro_Name, 3).
+-define(Bad_L33t_M@Cr0, 4).
 
--define(GOOD, good).
--define(GOOD_MACRO_NAME, good).
+-define(GOOD, 5).
+-define(GOOD_MACRO_NAME, 6).

--- a/src/macros.erl
+++ b/src/macros.erl
@@ -1,0 +1,32 @@
+-module(macros).
+
+-define(OTHER_MODULE, other_module).
+-define(LOG_ERROR(Error),
+        error_logger:error_msg(
+          "~p:~p >> Error: ~p~n\tStack: ~p",
+          [?MODULE, ?LINE, Error, erlang:get_stacktrace()])).
+
+-define(HTTP_CREATED, 201).
+
+-export([bad/0, good/0]).
+
+bad() ->
+  try
+    ?OTHER_MODULE:some_function(that, may, fail, 201)
+  catch
+    _:Error ->
+      ?LOG_ERROR(Error)
+  end.
+
+good() ->
+  try
+    other_module:some_function(that, may, fail, ?HTTP_CREATED)
+  catch
+    _:Error ->
+      log_error(?LINE, Error)
+  end.
+
+log_error(Line, Error) ->
+  error_logger:error_msg(
+    "~p:~p >> Error: ~p~n\tStack: ~p",
+    [?MODULE, Line, Error, erlang:get_stacktrace()]).


### PR DESCRIPTION
##### rule

>  Macros should not be used as abbreviations. Also, no code should be allowed in macros, except for extenuating circumstances which must be documented.

``` erlang
##### bad
-define(IS_VALID_SERVICE(__Service), lists:member(__Service, pg2:which_groups())).
-define(IS_VISIBLE_SERVICE(__Service), (lists:keyfind(__Service, 1, application:which_applications()) =/= false)).
```
##### reasoning

Having logic in macros obscures its meaning. If having the code there complicate the logic, or duplicates code, or the logic is not related to the location the macro is invoked, then the macro'ed code should be in a function, with a proper semantic name.
