### PR TITLE
Suggestion: Do not share types by including them in hrl files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Table of Contents:
     * [Avoid records in specs](#avoid-records-in-specs)
     * [Use -callback attributes over behaviour_info/1](use--callback-attributes-over-behaviour_info1)
     * [No nested header inclusion](#no-nested-header-inclusion)
+    * [No types in include files](#no-types-in-include-files)
   * [Tools](#tools)
     * [Lock your dependencies](#lock-your-dependencies)
     * [Loud errors](#loud-errors)
@@ -295,6 +296,17 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 *Examples*: [nested](include/nested.hrl)
 
 *Reasoning*: ``-include`` directives in included headers may lead to duplication of inclusions and/or other conflicts and it also hides things from the developer view.
+
+***
+##### No types in include files
+> No `-type` in hrl files
+
+*Examples*: [types](src/types.erl)
+
+*Reasoning*: Defining types in public header files (especially those intended for inclusion via `-include_lib()`) might lead to type name clashes between projects and even modules of a single big project.
+Instead, types should be defined in modules which they correspond to (with `-export_type()`) and this way take advantage of the namespacing offered by module names.
+In other words, "no type definitions in header files" rule means that we will always need to use `some_mod:some_type()` unless referring to a type from the same module it's defined in.
+Following this rule you also get the benefits that `-opaque` types provide, for instance, to dialyzer.
 
 ### Tools
 

--- a/include/bad_types.hrl
+++ b/include/bad_types.hrl
@@ -1,0 +1,5 @@
+-type type_id() :: pos_integer().
+-type type() :: proplists:proplist().
+
+%% If you later want to use these types on your specs you have to include this
+%% file and write stuff like -spec my_function(type_id()) -> type().

--- a/src/types.erl
+++ b/src/types.erl
@@ -1,0 +1,12 @@
+-module(types).
+
+-incldue("bad_types.hrl").
+
+-type id() :: pos_integer().
+
+-record(type, {id :: id(), name :: binary()}).
+-opaque type() :: #type{}.
+
+-export_type([id/0, type/0]).
+%% If you later want to use these types on your specs you DO NOT have to include
+%% any file and you just write -spec my_function(types:id()) -> types:type().


### PR DESCRIPTION
##### rule

> No `-type` in hrl files

``` erlang
%% bad
-type my_type() :: [another_type()].
```
##### reasoning

Defining types in public header files (especially those intended for inclusion via `-include_lib()`) might lead to type name clashes between projects and even modules of a single big project.
Instead, types should be defined in modules which they correspond to (with `-export_type()`) and this way take advantage of the namespacing offered by module names.
In other words, "no type definitions in header files" rule means that we will always need to use `some_mod:some_type()` unless referring to a type from the same module it's defined in.
