### PR TITLE
Suggestion: use lists:foreach or LC instead of lists:map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ I swear I heard Joe mutter this while taking a nap at the office.
 
 One rule per issue.
 
-When discussed and approved, it will be moved to either the *Conventions* or the *Great Ideas* list. If rejected, it will be moved to the *Rejected* list.
+When discussed and approved, it will be moved to either the *Conventions* or the *Great Ideas* list. If rejected, it will be moved to the [*Rejected*](REJECTED.md) list.
 
 ### Acceptance criteria
 

--- a/REJECTED.md
+++ b/REJECTED.md
@@ -1,0 +1,25 @@
+## Rejected rules and suggestions
+
+***
+
+##### rule
+>  Use tail-recursive functions instead of foldl
+
+##### rejected because
+  We love high-order functions!
+
+***
+
+##### rule
+>  Using ``'andalso'``, ``'orelse'``, and the like, might save a 'case' or two
+
+##### rejected because
+  They're not intended to be used that way and the resulting code messes up with dialyzer
+
+***
+
+##### rule
+> Replace ``lists:map`` with either ``lists:foreach`` or list comprehensions
+
+##### rejected because
+  There is not true that LCs are better than ``list:map`` in all scenarios.


### PR DESCRIPTION
##### rule

>  Replace `lists:map` with either `lists:foreach` or list comprehensions

``` erlang
%% bad
  lists:map(
    fun(#rec{field=Value}) ->
      process(Value)
    end, List).

%% good (in case you want the results)
  [process(Value) || #rec{field=Value} <- List].

%% good (in case you don't want to use the results)
  lists:foreach(
    fun(#rec{field=Value}) ->
      process(Value)
    end, List).
```
##### reasoning

  If you're not using the results, you should not generate them (thus the need for `foreach` that always return `ok`). On the other hand, if you **do** need them, list comprehensions are clearer, shorter, etc. **unless** you do stuff like `lists:map(fun process_rec/1, List)`
