### PR TITLE
Atom names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Table of Contents:
     * [Don't use _Ignored variables](#dont-use-_ignored-variables)
     * [Avoid boolean parameters](#avoid-boolean-parameters)
     * [Stick to one convention for naming modules](#stick-to-one-convention-for-naming-modules)
+    * [Lowercase atoms](#lowercase-atoms)
   * [Strings](#strings)
     * [IOLists over string concatenation](#iolists-over-string-concatenation)
   * [Macros](#macros)
@@ -256,6 +257,14 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 *Examples*: [naming_modules](src/naming_modules)
 
 *Reasoning*: It gives coherence to your system.
+
+***
+##### Lowercase atoms
+> Atoms should use only lowercase characters. Words in atom names should be separated with `_`. Special cases are allowed (like `'GET'`, `'POST'`, etc.) but should be properly justified.
+
+*Examples*: [atoms](src/atoms.erl)
+
+*Reasoning*: Adhering one convention makes it easier not to have "duplicated" atoms all around the code. Also, not using caps or special characters reduces the need for `'` around atoms.
 
 ### Strings
 

--- a/src/atoms.erl
+++ b/src/atoms.erl
@@ -1,0 +1,7 @@
+-module(atoms).
+
+-export([bad/0, good/0]).
+
+bad() -> ['BAD', alsoBad, bad_AS_well].
+
+good() -> [good, also_good, 'good@its.mail'].


### PR DESCRIPTION
Atoms should use only lowercase characters. Words in atom names should be separated with “_”, e.g. as in special_msg. In special cases, such as protocol defined atoms (e.g.
’POST’ and ’GET’ in HTTP), atoms should use the protocol defined spelling.
