### PR TITLE
Function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Table of Contents:
     * [Avoid boolean parameters](#avoid-boolean-parameters)
     * [Stick to one convention for naming modules](#stick-to-one-convention-for-naming-modules)
     * [Lowercase atoms](#lowercase-atoms)
+    * [Function Names](#function-names)
   * [Strings](#strings)
     * [IOLists over string concatenation](#iolists-over-string-concatenation)
   * [Macros](#macros)
@@ -265,6 +266,14 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 *Examples*: [atoms](src/atoms.erl)
 
 *Reasoning*: Adhering one convention makes it easier not to have "duplicated" atoms all around the code. Also, not using caps or special characters reduces the need for `'` around atoms.
+
+***
+##### Function Names
+> Function names must use only lowercase characters. Words in function names must be separated with `_`.
+
+*Examples*: [function_names](src/function_names.erl)
+
+*Reasoning*: Function names are atoms, they should follow the same rules that apply to them.
 
 ### Strings
 

--- a/src/function_names.erl
+++ b/src/function_names.erl
@@ -1,0 +1,9 @@
+-module(function_names).
+
+-export([badFunction/0, 'BAD_FUNCTION'/0, good_function/0]).
+
+badFunction() -> {not_allowed, camel_case}.
+
+'BAD_FUNCTION'() -> {not_allowed, upper_case}.
+
+good_function() -> ok.


### PR DESCRIPTION
---
##### rule

> Function names must use only lowercase characters. Words in function names must be separated with “_”, e.g. as in handle_request.

``` erlang
%% bad
horrible_erlang_code() ->
  just_awful.

%% good
beautiful_erlang_code() ->
  much_better.
```
##### reasoning

I swear I heard Joe mutter this while taking a nap at the office.

---
