### PR TITLE
Types in exported functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Table of Contents:
   * [Avoid unnecesary calls to length/1](#avoid-unnecesary-calls-to-length1)
   * [Move stuff to independent applications](#move-stuff-to-independent-applications)
   * [Use the facade pattern on libraries](#use-the-facade-pattern-on-libraries)
+  * [Types in exported functions](#types-in-exported-functions)
 
 ## Contact Us
 
@@ -589,3 +590,11 @@ If you don't tighten up the function head, the gen_server will crash.
 
 *Reasoning*: Having the relevant functions in a single module means that the end user doesn't have a hard time figuring out which functions to call. Note that to avoid making it too complex, you probably want to carefully consider which functionality you wish to support here; exposing fewer functions (the ones that show the basic use of the library) as opposed to just creating a dummy module containing every single exported function in the library is prefered.
 This greatly reduces the learning curve of the library and therefore makes it more tempting to use.
+
+***
+##### Types in exported functions
+> Custom data types used in exported functions should be defined with Erlang type declarations and exported from the module
+
+*Examples*: [data_types](src/data_types.erl)
+
+*Reasoning*: It helps with function documentation and, when using opaque types, we ensure encapsulation.

--- a/src/data_types.erl
+++ b/src/data_types.erl
@@ -1,0 +1,13 @@
+-module(data_types).
+
+-export([bad/1, good/1]).
+
+-type your_type() :: {integer(), string()}.
+-opaque my_type() :: {binary(), binary()}.
+-export_type([your_type/0, my_type/0]).
+
+-spec good(your_type()) -> {ok, my_type()}.
+good({I, S}) -> {ok, {integer_to_binary(I), list_to_binary(S)}}.
+
+-spec bad({integer(), string()}) -> {ok, {binary(), binary()}}.
+bad({I, S}) -> {ok, {integer_to_binary(I), list_to_binary(S)}}.


### PR DESCRIPTION
---
##### rule

> All custom data types used in exported functions should be defined with Erlang type declarations and exported from the module

``` erlang
%% bad
-spec exported_function({integer(), string()}) -> {ok, {binary(), binary()}}.

%% good
-type your_type() :: {integer(), string()}.
-opaque my_type() :: {binary(), binary()}.
-export_type([your_type/0, my_type/0]).
-spec exported_function(your_type()) -> {ok, my_type()}.
```
##### reasoning

It helps with function documentation and, with opaque types we ensure encapsulation.
