### PR TITLE
Get your types together!

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Table of Contents:
     * [Avoid deep nesting](#avoid-deep-nesting)
     * [More, smaller functions over case expressions](#more-smaller-functions-over-case-expressions)
     * [Group functions logically](#group-functions-logically)
+    * [Get your types together](#get-your-types-together)
     * [No God modules](#no-god-modules)
     * [Simple unit tests](#simple-unit-tests)
     * [Honor DRY](#honor-dry)
@@ -148,6 +149,14 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 *Examples*: [grouping_functions](src/grouping_functions)
 
 *Reasoning*: Well structured code is easier to read/understand/modify.
+
+***
+##### Get your types together
+> Place all types at the beginning of the file
+
+*Examples*: [type_placement](src/type_placement.erl)
+
+*Reasoning*: Types are used to define data structures that will most likely be used by multiple functions on the module, so their definition can not be tied to just one of them. Besides it's a good practice to place them in code in a similar way as the documentation presents them and edoc puts types at the beginning of each module documentation
 
 ***
 ##### No God modules

--- a/src/type_placement.erl
+++ b/src/type_placement.erl
@@ -1,0 +1,13 @@
+-module(type_placement).
+
+-export([good/0, bad/0]).
+
+-type good_type() :: 1..3.
+
+-spec good() -> good_type().
+good() -> 2.
+
+
+-type bad_type() :: 1..3.
+-spec bad() -> bad_type().
+bad() -> 2.


### PR DESCRIPTION
---
##### rule

> Place all types at the beginning of the file

``` erlang
%% bad
-type a_type() :: term().
-spec a_fun(a_type()) -> ok.

-type another_type() :: term().

%% good
-type a_type() :: term().
-type another_type() :: term().

-spec a_fun(a_type()) -> ok.
```
##### reasoning

It's easier to find all types defined in a module. Also, it matches the documentation generated by edoc.
