### PR TITLE
Remove NOTE about rebar from Subdirectory rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 
 *Reasoning*: That way it's easier to find what you need and determine what a certain module does.
 
-*Note*: Remember to properly configure your ``Emakefile`` and ``rebar.config`` to handle that
+*Note*: Remember to properly configure your ``Emakefile`` to handle that, if you use it.
 
 ***
 ##### Don't write spaghetti code


### PR DESCRIPTION
Check [this rule](https://github.com/inaka/erlang_guidelines#group-modules-in-subdirectories-by-functionality): The note is outdated about rebar.config, now it doesn't require to change src dirs anymore.