### PR TITLE
Fixed case of variable `Arg` in dyn_calls

### DIFF
--- a/src/dyn_calls.erl
+++ b/src/dyn_calls.erl
@@ -13,4 +13,4 @@ bad(Arg) ->
 good(Arg) ->
   mdoule_1:my_function(Arg),
   module_2:my_function(Arg),
-  module_3:my_function(arg).
+  module_3:my_function(Arg).


### PR DESCRIPTION
The typo was mistakenly transforming the variable `Arg` into the symbol `arg`.