### PR TITLE
Prefer Pattern Matching over Equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Table of Contents:
     * [Properly use logging levels](#properly-use-logging-levels)
     * [Prefer the https protocol when specifying dependency locations](#prefer-the-https-protocol-over-others-when-specifying-dependency-urls)
 * [Suggestions & Great Ideas](#suggestions--great-ideas)
+  * [Prefer pattern-matching over testing for equality](#prefer-pattern-matching-over-testing-for-equality)
   * [Favor higher-order functions over manual use of recursion](#favor-higher-order-functions-over-manual-use-of-recursion)
   * [CamelCase over Under_Score](#camelcase-over-under_score)
   * [Prefer shorter (but still meaningful) variable names](#prefer-shorter-but-still-meaningful-variable-names)
@@ -551,6 +552,15 @@ handling.
 ## Suggestions & Great Ideas
 
 Things that should be considered when writing code, but do not cause a PR rejection, or are too vague to consistently enforce.
+
+***
+##### Prefer pattern-matching over testing for equality
+> When you want to write a conditional statement based on a comparison of two values, don't use equality and then switch according to the boolean result value. Use pattern matching instead.
+
+*Examples*: [pattern matching](src/prefer_pm.erl)
+
+*Reasoning*:
+From a semantic standpoint, _boolean switches_ after _equality_ introduce static boolean logic in your code, reducing its flexibility. Besides, pattern matching is just more declarative. And, specially in the case where there is a function involved, using pattern matching you get a chance to _do something_ with the result of such a function call.
 
 ***
 ##### Favor higher-order functions over manual use of recursion

--- a/src/prefer_pm.erl
+++ b/src/prefer_pm.erl
@@ -1,0 +1,43 @@
+-module(prefer_pm).
+
+-export ([good/3, bad/3]).
+
+%% @doc Uses equality comparisons (=:=) for everything
+-spec bad(T, T, 0|1|2) -> ok.
+bad(A, B, 0) ->
+  case A =:= B of
+    true -> proceed();
+    false -> fail(A)
+  end;
+bad(A, B, 1) ->
+  case change(A) =:= B of
+    true -> proceed();
+    false -> fail(A)
+  end;
+bad(A, B, 2) ->
+  case change(A) =:= change(B) of
+    true -> proceed();
+    false -> fail(A)
+  end.
+
+%% @doc Uses pattern-matching everywhere
+-spec good(T, T, 0|1|2) -> ok.
+good(A, B, 0) ->
+  case A of
+    B -> proceed();
+    A -> fail(A)
+  end;
+good(A, B, 1) ->
+  case change(A) of
+    B -> proceed();
+    C -> fail(C)
+  end;
+good(A, B, 2) ->
+  case {change(A), change(B)} of
+    {C, C} -> proceed();
+    {D, _} -> fail(D)
+  end.
+
+change(X) -> {changed, X}.
+proceed() -> ok.
+fail(E) -> exit({error, E}).


### PR DESCRIPTION
---
##### rule

> When you want to write a conditional statement based on a comparison of two values, don't use equality and then switch according to the boolean result value. Use pattern matching instead.

``` erlang
%% bad
case A =:= B of
  true -> proceed();
  false -> fail(A)
end.
case change(A) =:= B of
  true -> proceed();
  false -> fail(A)
end.
case change(A) =:= change(B) of
  true -> proceed();
  false -> fail(A)
end.

%% good
case A of
  B -> proceed();
  A -> fail(A)
end.
case change(A) of
  B -> proceed();
  C -> fail(C)
end.
case {change(A), change(B)} of
  {C, C} -> proceed();
  {D, _} -> fail(D)
end.
```
##### reasoning

From a semantic standpoint, _boolean switches_ after _equality_ introduce static boolean logic in your code, reducing its flexibility. Besides, pattern matching is just more declarative. And, specially in the case where there is a function involved, using pattern matching you get a chance to _do something_ with the result of such a function call.
