### PR TITLE
Explicit state should be explicitly annotated with a module prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,11 +272,14 @@ Erlang syntax is horrible amirite? So you might as well make the best of it, rig
 
 ***
 ##### Explicit state should be explicitly named
-> Name your state records ``#state`` and use ``-type state():: #state{}`` in all your OTP modules.
+> Name your state records ``#mod_state`` and use ``-type state():: #mod_state{}`` in all your modules that implement OTP behaviors.
 
 *Examples*: [state](src/state)
 
-*Reasoning*: OTP behaviours implementations usually require a state, and if it always have the same name it makes it more clearly recognizable. Defining a type for it, helps _dialyzer_ detect leaks (where an internal type as the state is used outside of the module).
+*Reasoning*: OTP behaviours implementations usually require a state, and if it has a recognizable name it makes it more easily identifiable. Defining a type for it, helps _dialyzer_ detect leaks (where an internal type as the state is used outside of the module).
+The usage of the module prefix in the record name has the goal of distinguishing different state tuples while debugging: Since records are just tuples when one is dumped into the shell it is easier to read `{good_state, att1, attr2}` than `{state, attr1, attr2, attr3}` or `{state, attr1, att2}`.
+At a glance you know that the tuple/record can be found in the `good.erl`module.
+
 
 ***
 ##### Don't use _Ignored variables

--- a/src/state/good.erl
+++ b/src/state/good.erl
@@ -6,9 +6,9 @@
 -export([init/1, terminate/2, code_change/3,
          handle_call/3, handle_cast/2, handle_info/2]).
 
--record(state, {value :: pos_integer()}).
+-record(good_state, {value :: pos_integer()}).
 
--type state() :: #state{}.
+-type state() :: #good_state{}.
 
 -spec start(pos_integer()) -> {ok, pid()}.
 start(InitialValue) ->
@@ -22,16 +22,16 @@ increment() -> gen_server:cast(?MODULE, increment).
 
 
 -spec init(pos_integer()) -> {'ok', state()}.
-init(InitialValue) -> {ok, #state{value = InitialValue}}.
+init(InitialValue) -> {ok, #good_state{value = InitialValue}}.
 
 -spec handle_call(retrieve, {pid(), term()}, state()) ->
         {'reply', pos_integer(), state()}.
 handle_call(retrieve, _From, State) ->
-  {reply, State#state.value, State}.
+  {reply, State#good_state.value, State}.
 
 -spec handle_cast(increment, state()) -> {'noreply', state()}.
 handle_cast(increment, State) ->
-  {noreply, State#state{value = State#state.value + 1}}.
+  {noreply, State#good_state{value = State#good_state.value + 1}}.
 
 -spec handle_info(any(), state()) -> {'noreply', state()}.
 handle_info(_Msg, State) -> {noreply, State}.


### PR DESCRIPTION
Currently the style guide proposes

Name your state records #state and use -type state():: #state{} in all your OTP modules.

I am suggesting we change this to

Name your state records #mod_state and use -type mod_state():: #mod_state{} in all your OTP modules.

Example:
good.erl:
  -record(good_state, ......)

Since records are just tuples when this is dumped into the shell it is easier to read {good_state, att1, attr2} then {state, attr1, attr2, attr3} .... {state, attr1, att2}. 

At a glance I know that the tuple/record can be found in the good.erl module. Did you notice I had 2 different state tuples in the example above ? This is a relatively short lines of code, imagine a screenful while supporting a system.  
