### PR TITLE
Do not use timer:sleep/1 in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Table of Contents:
     * [Loud errors](#loud-errors)
     * [Properly use logging levels](#properly-use-logging-levels)
     * [Prefer the https protocol when specifying dependency locations](#prefer-the-https-protocol-over-others-when-specifying-dependency-urls)
+    * [No implicit functions with mixer](#no-implicit-functions-with-mixer)
 * [Suggestions & Great Ideas](#suggestions--great-ideas)
   * [Favor higher-order functions over manual use of recursion](#favor-higher-order-functions-over-manual-use-of-recursion)
   * [CamelCase over Under_Score](#camelcase-over-under_score)
@@ -547,6 +548,13 @@ handling.
 * [Git on the Server - The Protocols](http://git-scm.com/book/ch4-1.html)
 * [GitHub Official Recommendation](https://help.github.com/articles/which-remote-url-should-i-use/)
 * [GitHub Protocol Comparison](https://gist.github.com/grawity/4392747#file-github-protocol-comparison-md)
+
+##### No implicit functions with mixer
+> Don't implicitly include all functions from a module when using the [mixer](https://github.com/chef/mixer) library. Explicitly list all mixed-in functions.
+
+*Examples*: [mixer](src/mixer.erl)
+
+*Reasoning*: Knowing all the functions that are included in a module makes it easier to reason about it. If any number of functions are implicitly brought from another module, it introduces an extra level of unnecessary indirection that requires jumping back and forth between files. The less information we have to keep in our heads the better.
 
 ## Suggestions & Great Ideas
 

--- a/src/sleepy.erl
+++ b/src/sleepy.erl
@@ -1,0 +1,12 @@
+-module(sleepy).
+
+-export([bad/1, good/1]).
+
+bad(_Config) ->
+    something:that(kicks, off, a, {background, task}),
+    timer:sleep(1000),
+    done = that_task:status().
+
+good(_Config) ->
+    something:that(kicks, off, a, {background, task}),
+    ktn_task:wait_for(fun() -> that_task:status() end, done).


### PR DESCRIPTION
***
##### Do not use `timer:sleep/1` in tests
> When testing some asynchronous behavior, you should never rely on letting your test sleep for a long enough time. You should use some polling mechanism, instead.

```erlang
%% bad
bad(Config) ->
    something:that(kicks, off, a, {background, task}),
    timer:sleep(1000),
    done = that_task:status().

%% good
good(Config) ->
    something:that(kicks, off, a, {background, task}),
    ktn_task:wait_for(fun() -> that_task:status() end, done).
```

*Reasoning*: If you use `timer:sleep/1` with a number that's too small, scheduler load or other factors may randomly make your test fail. On the other hand, using a number that's big enough to ensure test success may waste lots of time in each run thus slowing down your test suite and your development process as a whole. Using `ktn_task:wait_for/2` or similar alternatives (i.e. periodically polling for results until the right one is found), you get the best of both worlds: you don't fail too early but you also don't wait too much.